### PR TITLE
test feature/fix-client-id-usage works

### DIFF
--- a/up-transport-vsomeip/src/lib.rs
+++ b/up-transport-vsomeip/src/lib.rs
@@ -197,6 +197,17 @@ impl UPTransportVsomeip {
         config_path: Option<&Path>,
         runtime_config: Option<RuntimeConfig>,
     ) -> Result<Self, UStatus> {
+        let check_ue_version_major: Result<u8, _> = uri.ue_version_major.try_into();
+        if check_ue_version_major.is_err() {
+            return Err(UStatus::fail_with_code(
+                UCode::INVALID_ARGUMENT,
+                format!(
+                    "uri's ue_version_major doesn't fit allotted 8 bits: uri.ue_version_major: {}",
+                    uri.ue_version_major
+                ),
+            ));
+        }
+
         uri.verify_rpc_response().map_err(|e| {
             UStatus::fail_with_code(
                 UCode::INVALID_ARGUMENT,

--- a/up-transport-vsomeip/src/storage.rs
+++ b/up-transport-vsomeip/src/storage.rs
@@ -124,15 +124,19 @@ impl RpcCorrelationRegistry for UPTransportVsomeipStorage {
         &self,
         someip_request_id: SomeIpRequestId,
         uprotocol_req_id: &UProtocolReqId,
+        source_uri: &UUri,
     ) -> Result<(), UStatus> {
-        self.rpc_correlation
-            .insert_ue_request_correlation(someip_request_id, uprotocol_req_id)
+        self.rpc_correlation.insert_ue_request_correlation(
+            someip_request_id,
+            uprotocol_req_id,
+            source_uri,
+        )
     }
 
     fn remove_ue_request_correlation(
         &self,
         someip_request_id: SomeIpRequestId,
-    ) -> Result<UProtocolReqId, UStatus> {
+    ) -> Result<(UProtocolReqId, UUri), UStatus> {
         self.rpc_correlation
             .remove_ue_request_correlation(someip_request_id)
     }

--- a/vsomeip-proc-macro/src/lib.rs
+++ b/vsomeip-proc-macro/src/lib.rs
@@ -103,8 +103,10 @@ pub fn generate_message_handler_extern_c_fns(input: TokenStream) -> TokenStream 
                     let remote_authority_name = transport_storage.get_remote_authority();
 
                     let transport_storage_clone = transport_storage.clone();
+                    let uri = transport_storage.get_uri();
                     let res = VsomeipMessageToUMessage::convert_vsomeip_msg_to_umsg(
                         &authority_name,
+                        &uri,
                         &remote_authority_name,
                         transport_storage_clone,
                         &mut vsomeip_msg_wrapper,


### PR DESCRIPTION
Update UMessage Request -> vsomeip msg to store source UUri. Update vsomeip msg Response -> UMessage to use cached Request's source UUri. Update vsomeip msg Request -> UMessage to use the configured ue_id and ue_version_major.